### PR TITLE
Add Syati as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Syati"]
+	path = Syati
+	url = https://github.com/MasterofGalaxies/Syati.git

--- a/build.py
+++ b/build.py
@@ -1,0 +1,9 @@
+import sys
+import Syati.build
+
+# Get the target region from the command line
+if len(sys.argv) < 2:
+    print("Error: Did not specify a target region.")
+    sys.exit(1)
+
+Syati.build.build(sys.argv[1], ["include", "Syati/include"])


### PR DESCRIPTION
This way, Syati no longer has to be manually and uncleanly merged.

When https://github.com/Lord-Giganticus/Syati/pull/1 gets merged, I will update this to use that repository as the submodule instead of my fork.